### PR TITLE
Fix hero testimonial effect

### DIFF
--- a/src/components/landing/hero-section.tsx
+++ b/src/components/landing/hero-section.tsx
@@ -56,13 +56,6 @@ export default function HeroSection() {
       setCurrentTestimonial((prev) => (prev + 1) % testimonials.length);
     }, 4000);
     return () => clearInterval(interval);
-  }, []);
-
-  useEffect(() => {
-    const interval = setInterval(() => {
-      setCurrentTestimonial((prev) => (prev + 1) % testimonials.length);
-    }, 4000);
-    return () => clearInterval(interval);
   }, [testimonials.length]);
 
   return (


### PR DESCRIPTION
## Summary
- consolidate `useEffect` hooks into a single hook
- keep visibility state set on mount while rotating testimonials

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_684868f3981c832b8c23fe75ec70db1a